### PR TITLE
Remove hardcoded output path /var/spool/cwl

### DIFF
--- a/delly_docker/Dockstore.cwl
+++ b/delly_docker/Dockstore.cwl
@@ -34,11 +34,15 @@ inputs:
     inputBinding:
       position: 3
       prefix: --tumor-bam
+    secondaryFiles:
+    - .bai
   normal-bam:
     type: File
     inputBinding:
       position: 2
       prefix: --normal-bam
+    secondaryFiles:
+    - .bai
   reference-gz:
     type: File
     inputBinding:

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -60,6 +60,8 @@ GetOptions (
 # TODO: need to add all the new params, then symlink the ref files to the right place
  or die("Error in command line arguments\n");
 
+run("export HOME=$output_dir")
+
 # check our assumptions
 run("env");
 run("whoami");

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -60,7 +60,7 @@ GetOptions (
 # TODO: need to add all the new params, then symlink the ref files to the right place
  or die("Error in command line arguments\n");
 
-run("export HOME=$output_dir")
+$ENV{'HOME'} = $output_dir
 
 # check our assumptions
 run("env");
@@ -74,9 +74,9 @@ system("gosu root chmod a+rwx /tmp");
 run("mkdir -p /datastore/normal/");
 run("mkdir -p /datastore/tumor/");
 run("ln -sf $normal_bam /datastore/normal/normal.bam");
-run("ln -sf ${normal_bam}.bai /data/datastore/normal/normal.bam.bai");
+run("ln -sf $normal_bam.bai /data/datastore/normal/normal.bam.bai");
 run("ln -sf $tumor_bam /datastore/tumor/tumor.bam");
-run("ln -sf ${tumor_bam}.bai /data/datastore/tumor/tumor.bam.bai");
+run("ln -sf $tumor_bam.bai /data/datastore/tumor/tumor.bam.bai");
 run("mkdir -p /datastore/data/");
 #run("ln -sf $reference_gz /datastore/data/genome.fa.gz");
 #run("gunzip /datastore/data/genome.fa.gz");
@@ -110,10 +110,10 @@ close OUT;
 
 # NOW RUN WORKFLOW
 # workaround for docker permissions 
-run("gosu root mkdir -p ${output_dir}/.seqware");
-run("gosu root chown -R seqware ${output_dir}");
-run("gosu root cp /home/seqware/.seqware/settings ${output_dir}/.seqware");
-run("gosu root chmod a+wrx ${output_dir}/.seqware/settings");
+run("gosu root mkdir -p $output_dir/.seqware");
+run("gosu root chown -R seqware $output_dir");
+run("gosu root cp /home/seqware/.seqware/settings $output_dir/.seqware");
+run("gosu root chmod a+wrx $output_dir/.seqware/settings");
 run("perl -pi -e 's/wrench.res/seqwaremaven/g' /home/seqware/bin/seqware");
 my $error = system("seqware bundle launch --dir /home/seqware/DELLY/target/Workflow_Bundle_DELLY_".$wfversion."_SeqWare_1.1.1  --engine whitestar --ini /datastore/workflow.ini --no-metadata");
 
@@ -122,7 +122,7 @@ my $path = `ls -1t /datastore/ | grep 'oozie-' | head -1`;
 chomp $path;
 
 # MOVE THESE TO THE RIGHT PLACE
-system("gosu root mv /datastore/$path/*.vcf.gz /datastore/$path/*.bedpe.txt /datastore/$path/delly_results/*.sv.cov.tar.gz /datastore/$path/delly_results/*.sv.cov.plots.tar.gz /datastore/$path/*.sv.log.tar.gz /datastore/$path/*.json ${output_dir}");
+system("gosu root mv /datastore/$path/*.vcf.gz /datastore/$path/*.bedpe.txt /datastore/$path/delly_results/*.sv.cov.tar.gz /datastore/$path/delly_results/*.sv.cov.plots.tar.gz /datastore/$path/*.sv.log.tar.gz /datastore/$path/*.json $output_dir");
 
 # RETURN RESULT
 exit($error);

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -43,13 +43,14 @@ use Cwd;
 
 
 my @files;
-my ($run_id, $normal_bam, $tumor_bam, $reference_gz, $reference_gc);
+my ($output_dir, $run_id, $normal_bam, $tumor_bam, $reference_gz, $reference_gc);
 my $cwd = cwd();
 
 # workflow version
 my $wfversion = "2.0.0";
 
 GetOptions (
+  "output-dir=s"  => \$output_dir,
   "run-id=s"   => \$run_id,
   "normal-bam=s" => \$normal_bam,
   "tumor-bam=s" => \$tumor_bam,
@@ -70,15 +71,15 @@ system("gosu root chmod a+rwx /tmp");
 # SYMLINK REF FILES
 run("mkdir -p /datastore/normal/");
 run("mkdir -p /datastore/tumor/");
-run("ln -s $normal_bam /datastore/normal/normal.bam");
-run("samtools index /datastore/normal/normal.bam");
-run("ln -s $tumor_bam /datastore/tumor/tumor.bam");
-run("samtools index /datastore/tumor/tumor.bam");
+run("ln -sf $normal_bam /datastore/normal/normal.bam");
+run("ln -sf ${normal_bam}.bai /data/datastore/normal/normal.bam.bai");
+run("ln -sf $tumor_bam /datastore/tumor/tumor.bam");
+run("ln -sf ${tumor_bam}.bai /data/datastore/tumor/tumor.bam.bai");
 run("mkdir -p /datastore/data/");
-#run("ln -s $reference_gz /datastore/data/genome.fa.gz");
+#run("ln -sf $reference_gz /datastore/data/genome.fa.gz");
 #run("gunzip /datastore/data/genome.fa.gz");
 system("gunzip -c $reference_gz > /datastore/data/hg19_1_22XYMT.fa");
-run("ln -s $reference_gc /datastore/data/hg19_1_22XYMT.gc");
+run("ln -sf $reference_gc /datastore/data/hg19_1_22XYMT.gc");
 
 # MAKE CONFIG
 # the default config is the workflow_local.ini and has most configs ready to go
@@ -107,10 +108,10 @@ close OUT;
 
 # NOW RUN WORKFLOW
 # workaround for docker permissions 
-run("gosu root mkdir -p /var/spool/cwl/.seqware");
-run("gosu root chown -R seqware /var/spool/cwl/");
-run("gosu root cp /home/seqware/.seqware/settings /var/spool/cwl/.seqware");
-run("gosu root chmod a+wrx /var/spool/cwl/.seqware/settings");
+run("gosu root mkdir -p ${output_dir}/.seqware");
+run("gosu root chown -R seqware ${output_dir}");
+run("gosu root cp /home/seqware/.seqware/settings ${output_dir}/.seqware");
+run("gosu root chmod a+wrx ${output_dir}/.seqware/settings");
 run("perl -pi -e 's/wrench.res/seqwaremaven/g' /home/seqware/bin/seqware");
 my $error = system("seqware bundle launch --dir /home/seqware/DELLY/target/Workflow_Bundle_DELLY_".$wfversion."_SeqWare_1.1.1  --engine whitestar --ini /datastore/workflow.ini --no-metadata");
 
@@ -119,7 +120,7 @@ my $path = `ls -1t /datastore/ | grep 'oozie-' | head -1`;
 chomp $path;
 
 # MOVE THESE TO THE RIGHT PLACE
-system("gosu root mv /datastore/$path/*.vcf.gz /datastore/$path/*.bedpe.txt /datastore/$path/delly_results/*.sv.cov.tar.gz /datastore/$path/delly_results/*.sv.cov.plots.tar.gz /datastore/$path/*.sv.log.tar.gz /datastore/$path/*.json $cwd");
+system("gosu root mv /datastore/$path/*.vcf.gz /datastore/$path/*.bedpe.txt /datastore/$path/delly_results/*.sv.cov.tar.gz /datastore/$path/delly_results/*.sv.cov.plots.tar.gz /datastore/$path/*.sv.log.tar.gz /datastore/$path/*.json ${output_dir}");
 
 # RETURN RESULT
 exit($error);

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -60,7 +60,7 @@ GetOptions (
 # TODO: need to add all the new params, then symlink the ref files to the right place
  or die("Error in command line arguments\n");
 
-$ENV{'HOME'} = $output_dir
+$ENV{'HOME'} = $output_dir;
 
 # check our assumptions
 run("env");
@@ -74,9 +74,9 @@ system("gosu root chmod a+rwx /tmp");
 run("mkdir -p /datastore/normal/");
 run("mkdir -p /datastore/tumor/");
 run("ln -sf $normal_bam /datastore/normal/normal.bam");
-run("ln -sf $normal_bam.bai /data/datastore/normal/normal.bam.bai");
+run("ln -sf $normal_bam.bai /datastore/normal/normal.bam.bai");
 run("ln -sf $tumor_bam /datastore/tumor/tumor.bam");
-run("ln -sf $tumor_bam.bai /data/datastore/tumor/tumor.bam.bai");
+run("ln -sf $tumor_bam.bai /datastore/tumor/tumor.bam.bai");
 run("mkdir -p /datastore/data/");
 #run("ln -sf $reference_gz /datastore/data/genome.fa.gz");
 #run("gunzip /datastore/data/genome.fa.gz");

--- a/delly_docker/scripts/start.sh
+++ b/delly_docker/scripts/start.sh
@@ -13,9 +13,8 @@ env
 # using '--workdir' in 'docker run' command by cwltool. Currently version
 # of cwltool set $PWD same as $HOME
 OUTPUT_DIR=$HOME
+# allow cwltool to pick up the results created by seqware
+gosu root chmod -R a+wrx $OUTPUT_DIR
 
 cd $OUTPUT_DIR
 gosu seqware bash -c "$* --output-dir $OUTPUT_DIR"
-
-# allow cwltool to pick up the results created by seqware
-gosu root chmod -R a+wrx $OUTPUT_DIR

--- a/delly_docker/scripts/start.sh
+++ b/delly_docker/scripts/start.sh
@@ -15,7 +15,7 @@ env
 OUTPUT_DIR=$HOME
 
 cd $OUTPUT_DIR
-gosu root bash -c "$* --output-dir $OUTPUT_DIR"
+gosu seqware bash -c "$* --output-dir $OUTPUT_DIR"
 
 # allow cwltool to pick up the results created by seqware
 gosu root chmod -R a+wrx $OUTPUT_DIR

--- a/delly_docker/scripts/start.sh
+++ b/delly_docker/scripts/start.sh
@@ -15,7 +15,7 @@ env
 OUTPUT_DIR=$HOME
 
 cd $OUTPUT_DIR
-gosu root bash -c "$* --output_dir $OUTPUT_DIR"
+gosu root bash -c "$* --output-dir $OUTPUT_DIR"
 
 # allow cwltool to pick up the results created by seqware
 gosu root chmod -R a+wrx $OUTPUT_DIR

--- a/delly_docker/scripts/start.sh
+++ b/delly_docker/scripts/start.sh
@@ -5,8 +5,17 @@ set -o pipefail
 set -x
 
 gosu root chmod a+wrx /tmp
-gosu root chmod a+wrx /var/spool/cwl
 env
-gosu seqware bash -c "$*"
-#allow cwltool to pick up the results created by seqware
-gosu root chmod -R a+wrx /var/spool/cwl
+
+# newer version of cwltool no longer mounts hardcoded '/var/spool/cwl'
+# as $HOME (used for output in the container). Need to pass current
+# user's $HOME as output-dir. The other choice is $PWD, which is set
+# using '--workdir' in 'docker run' command by cwltool. Currently version
+# of cwltool set $PWD same as $HOME
+OUTPUT_DIR=$HOME
+
+cd $OUTPUT_DIR
+gosu root bash -c "$* --output_dir $OUTPUT_DIR"
+
+# allow cwltool to pick up the results created by seqware
+gosu root chmod -R a+wrx $OUTPUT_DIR


### PR DESCRIPTION
This is similar to the fixes applied to Sanger and DKFZ workflows to remove hardcoded `/var/spool/cwl`. We just successfully tested it on Seven Bridges CGC platform.