### PR TITLE
Standard output names

### DIFF
--- a/delly_docker/Dockerfile
+++ b/delly_docker/Dockerfile
@@ -1,1 +1,1 @@
-Dockerfile-2.1.1
+Dockerfile-standard-output-names

--- a/delly_docker/Dockerfile
+++ b/delly_docker/Dockerfile
@@ -1,1 +1,1 @@
-Dockerfile-2.0.4
+Dockerfile-2.1.1

--- a/delly_docker/Dockerfile-2.1.1
+++ b/delly_docker/Dockerfile-2.1.1
@@ -1,0 +1,17 @@
+FROM quay.io/pancancer/pcawg_delly_workflow:feature_gosu_and_icgc_portal
+
+USER root
+
+RUN apt-get update && apt-get install -y \
+    cpanminus \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cpanm Capture::Tiny
+
+COPY scripts/run_seqware_workflow.pl /usr/bin/
+
+COPY scripts/start.sh /start.sh
+RUN chmod a+rx /start.sh
+
+USER seqware
+

--- a/delly_docker/Dockerfile-standard-output-names
+++ b/delly_docker/Dockerfile-standard-output-names
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     cpanminus \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cpanm Capture::Tiny
+RUN cpanm --no-lwp Capture::Tiny
 
 COPY scripts/run_seqware_workflow.pl /usr/bin/
 

--- a/delly_docker/Dockstore.cwl
+++ b/delly_docker/Dockstore.cwl
@@ -20,33 +20,33 @@ requirements:
 
 inputs:
   run-id:
-    type: string
+    type: string?
     inputBinding:
-      position: 1
+      position: 5
       prefix: --run-id
   reference-gc:
     type: File
     inputBinding:
-      position: 5
+      position: 4
       prefix: --reference-gc
   tumor-bam:
     type: File
     inputBinding:
-      position: 3
+      position: 2
       prefix: --tumor-bam
     secondaryFiles:
     - .bai
   normal-bam:
     type: File
     inputBinding:
-      position: 2
+      position: 1
       prefix: --normal-bam
     secondaryFiles:
     - .bai
   reference-gz:
     type: File
     inputBinding:
-      position: 4
+      position: 3
       prefix: --reference-gz
 
 outputs:

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -3,6 +3,8 @@
 use strict;
 use Getopt::Long;
 use Cwd;
+use Time::Piece;
+
 
 ########
 # ABOUT
@@ -45,6 +47,7 @@ use Cwd;
 my @files;
 my ($output_dir, $run_id, $normal_bam, $tumor_bam, $reference_gz, $reference_gc);
 my $cwd = cwd();
+my $date = localtime->strftime('%Y%m%d');
 
 # workflow version
 my $wfversion = "2.0.0";
@@ -88,6 +91,7 @@ run("ln -sf $reference_gc /datastore/data/hg19_1_22XYMT.gc");
 my $config = "
 # # key=datastore:type=text:display=T:display_name=ID for the current run, will be used to create filenames
 delly_runID=$run_id
+date=$date
 
 # # key=input_bam_path_tumor:type=text:display=T:display_name=The relative tumor BAM path, directory name only
 input_bam_path_tumor=tumor

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -69,11 +69,8 @@ if ($run_id eq "")
   $run_id = get_aliquot_id_from_bam($tumor_bam);
 }
 
-if ($run_id =~ /^[a-zA-Z0-9_-]+$/) {
-    print "run-id is: $run_id\n";
-} else {
-    die "Found run-id contains invalid character: $run_id\n";
-}
+$run_id =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
+print "run-id is: $run_id\n";
 
 $ENV{'HOME'} = $output_dir;
 
@@ -172,9 +169,7 @@ sub get_aliquot_id_from_bam {
   for ( split "\n", $stdout ) {
     chomp $_;
     if ( $_ =~ m/\tSM:([^\t]+)/ ) {
-      my $sm = $1;
-      $sm =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
-      $names{$sm} = 1;
+      $names{$1} = 1;
     }
     else {
       die "Found RG line with no SM field: $_\n\tfrom: $bam\n";

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -179,4 +179,5 @@ sub get_aliquot_id_from_bam {
     if ( scalar @keys > 1 );
   die "No SM entry found in: $bam\n" if ( scalar @keys == 0 );
   return $keys[0];
+}
 

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -66,7 +66,8 @@ GetOptions (
 
 if ($run_id eq "")
 {
-  $run_id = get_aliquot_id_from_bam($tumor_bam)
+  $run_id = get_aliquot_id_from_bam($tumor_bam);
+  print "run-id is: $run_id\n";
 }
 
 $ENV{'HOME'} = $output_dir;

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -66,7 +66,7 @@ GetOptions (
 
 if ($run_id eq "")
 {
-  $run_id = get_aliquot_id_from_bam($tumor_bam);
+  $run_id = get_run_id_from_sm_in_bam($tumor_bam);
 }
 
 if ($run_id =~ /^[a-zA-Z0-9_-]+$/) {
@@ -159,7 +159,7 @@ sub run {
 }
 
 
-sub get_aliquot_id_from_bam {
+sub get_run_id_from_sm_in_bam {
   # we don't really need to get the exact SM, we just use it as run-id if user did not provide one
   my $bam = shift;
   die "BAM file does not exist: $bam" unless ( -e $bam );

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -67,8 +67,8 @@ GetOptions (
 if ($run_id eq "")
 {
   $run_id = get_aliquot_id_from_bam($tumor_bam);
-  print "run-id is: $run_id\n";
 }
+print "run-id is: $run_id\n";
 
 $ENV{'HOME'} = $output_dir;
 

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -160,6 +160,7 @@ sub run {
 
 
 sub get_aliquot_id_from_bam {
+  # we don't really need to get the exact SM, we just use it as run-id if user did not provide one
   my $bam = shift;
   die "BAM file does not exist: $bam" unless ( -e $bam );
 
@@ -171,7 +172,9 @@ sub get_aliquot_id_from_bam {
   for ( split "\n", $stdout ) {
     chomp $_;
     if ( $_ =~ m/\tSM:([^\t]+)/ ) {
-      $names{$1} = 1;
+      $sm = $1;
+      $sm =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
+      $names{$sm} = 1;
     }
     else {
       die "Found RG line with no SM field: $_\n\tfrom: $bam\n";

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -69,8 +69,11 @@ if ($run_id eq "")
   $run_id = get_aliquot_id_from_bam($tumor_bam);
 }
 
-$run_id =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
-print "run-id is: $run_id\n";
+if ($run_id =~ /^[a-zA-Z0-9_-]+$/) {
+    print "run-id is: $run_id\n";
+} else {
+    die "Found run-id contains invalid character: $run_id\n";
+}
 
 $ENV{'HOME'} = $output_dir;
 
@@ -169,7 +172,9 @@ sub get_aliquot_id_from_bam {
   for ( split "\n", $stdout ) {
     chomp $_;
     if ( $_ =~ m/\tSM:([^\t]+)/ ) {
-      $names{$1} = 1;
+      my $sm = $1;
+      $sm =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
+      $names{$sm} = 1;
     }
     else {
       die "Found RG line with no SM field: $_\n\tfrom: $bam\n";

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -68,7 +68,12 @@ if ($run_id eq "")
 {
   $run_id = get_aliquot_id_from_bam($tumor_bam);
 }
-print "run-id is: $run_id\n";
+
+if ($run_id =~ /^[a-zA-Z0-9_-]+$/) {
+    print "run-id is: $run_id\n";
+} else {
+    die "Found run-id contains invalid character: $run_id\n";
+}
 
 $ENV{'HOME'} = $output_dir;
 

--- a/delly_docker/scripts/run_seqware_workflow.pl
+++ b/delly_docker/scripts/run_seqware_workflow.pl
@@ -172,7 +172,7 @@ sub get_aliquot_id_from_bam {
   for ( split "\n", $stdout ) {
     chomp $_;
     if ( $_ =~ m/\tSM:([^\t]+)/ ) {
-      $sm = $1;
+      my $sm = $1;
       $sm =~ s/[^\w^\-^_]/_/g;  # convert non-filename-friendly characters to underscores
       $names{$sm} = 1;
     }


### PR DESCRIPTION
- autoset run dateString in the ini file
- expose run-id to be optional at cwl level and set the default value of run-id to be SM in RG of BAM header
- standard the output files prefixed with the PCAWG convention: <run-id>.<workflowName>.<dateString>
- modify Dockerfile to install perl module